### PR TITLE
Fixes branch name for merge workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -3,7 +3,7 @@ name: "Apply on Merged PR"
 on:
   push:
     branches:
-      - master
+    - main
 
 jobs:
   terraform:


### PR DESCRIPTION
TL;DR
-----

Corrects copy/paste error in merge workflow

Details
-------

Updates the branch selection in the "Apply on Merged PR" workflow
to use the `main` branch of the repository, versus the `master`
branch that the YAML I "borrowed" from the internet used.
