### PR TITLE
Fixes TXT and CAA records

### DIFF
--- a/src/terraform/main.tf
+++ b/src/terraform/main.tf
@@ -96,8 +96,8 @@ resource "google_dns_record_set" "crdant_io_txt" {
   ttl          = 300
 
   rrdatas = [
-    "google-site-verification=KHbc9bEc7SGC_UXq_u0cWiUrLI4G_NAlo1XMXmkSZxY",
-    "v=spf1 include:_spf.google.com ~all"
+    "\"google-site-verification=KHbc9bEc7SGC_UXq_u0cWiUrLI4G_NAlo1XMXmkSZxY\"",
+    "\"v=spf1\" \"include:_spf.google.com\" \"~all\""
   ]
 }
 
@@ -108,7 +108,7 @@ resource "google_dns_record_set" "crdant_io_caa" {
   ttl          = 300
 
   rrdatas = [
-    "0 issue letsencrypt.org"
+    "0 issue \"letsencrypt.org\""
   ]
 }
 


### PR DESCRIPTION
TL;DR
-----

Updates the data in the TXT and CAA records to prevent spurious
mismatches

Details
-------

The value of the spam verification and CAA records that applied
correctly but replied on GCP making an update to put the right
quotes into the record. This led to spurious "changes" on plan/apply.
Updates the value to only show real changes.
